### PR TITLE
ci: serialize main pushes with shared concurrency group

### DIFF
--- a/.github/workflows/build-toc.yaml
+++ b/.github/workflows/build-toc.yaml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: main-push
+  cancel-in-progress: false
+
 jobs:
   build_toc:
     # Only run on PR merge or direct push to main

--- a/.github/workflows/update-token-count.yml
+++ b/.github/workflows/update-token-count.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: main-push
+  cancel-in-progress: false
+
 jobs:
   update-tokens:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add shared `concurrency: main-push` group to both `build-toc.yaml` and `update-token-count.yml`
- Serializes the two workflows that push to `main` on merge, avoiding the race where one's `git push` races the other's and fails

## Context
In PR #129's merge, `update-tokens` failed at the `Commit if changed` step because `build_toc` pushed `docs: Update TOC.md files` to main concurrently, causing `git push` to lose the race. See [failed run](https://github.com/LouisShark/chatgpt_system_prompt/actions/runs/24619956880).

With `cancel-in-progress: false`, the second workflow waits for the first to finish, then its `actions/checkout` pulls fresh main (including the first's commit) before computing and pushing.

## Test plan
- [x] `yaml.safe_load` both files — valid
- [x] `actionlint` — no new errors from this diff (only pre-existing warnings about outdated `actions/checkout@v3` in build-toc.yaml)
- [ ] Merge this PR and confirm both workflows complete successfully in sequence

https://claude.ai/code/session_01Mm5cao4DWuqXogHPaccCTy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change that only affects workflow scheduling. Primary risk is longer CI latency on `main` due to serialized runs.
> 
> **Overview**
> Adds a shared `concurrency: main-push` (with `cancel-in-progress: false`) to the `build-toc` and `update-token-count` GitHub Actions workflows.
> 
> This serializes runs that both commit/push to `main`, preventing intermittent failures caused by concurrent `git push` operations racing each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb8a293d480375f2eb8c09cfeaf3eba183bb50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->