### PR TITLE
ci: drop redundant pull_request_target trigger on build-toc

### DIFF
--- a/.github/workflows/build-toc.yaml
+++ b/.github/workflows/build-toc.yaml
@@ -5,13 +5,7 @@ name: Generate TOC on PR Merge or Push
 # It ensures that the table of contents stays up-to-date without manual intervention.
 
 on:
-  # Trigger on PR merge
-  pull_request_target:
-    types:
-      - closed
-    branches:
-      - main
-  # Trigger on direct pushes to main branch
+  # Trigger on direct pushes to main branch (also fires on PR merges)
   push:
     branches:
       - main
@@ -22,8 +16,6 @@ concurrency:
 
 jobs:
   build_toc:
-    # Only run on PR merge or direct push to main
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Drop `pull_request_target: closed` trigger from `build-toc.yaml`; `push: main` already fires on every merge
- Remove the now-unreachable `if:` condition on the job

## Context
Addresses the High-severity [Cursor Bugbot finding](https://github.com/LouisShark/chatgpt_system_prompt/pull/131#discussion_r3106339628) on #131: with both triggers active, a single merge produced **3 runs** in the shared `main-push` concurrency group — two `build_toc` (from `pull_request_target` + `push`) plus `update-tokens`. GitHub's 1-running + 1-pending cap would silently cancel a pending run, risking loss of the `update-tokens` run.

With only `push: main`, each merge produces exactly 2 runs (`build_toc`, `update-tokens`) that serialize cleanly.

## Test plan
- [x] `yaml.safe_load` + `actionlint` — no new errors (pre-existing outdated-action warnings only)
- [ ] Next merge touching `prompts/**` — observe `build_toc` and `update-tokens` run in sequence without cancellation

https://claude.ai/code/session_01Mm5cao4DWuqXogHPaccCTy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the GitHub Actions trigger conditions to avoid duplicate runs; it does not modify build or TOC-generation logic.
> 
> **Overview**
> Simplifies the `build-toc` GitHub Actions workflow to run **only** on `push` to `main` (which already occurs on PR merges), removing the redundant `pull_request_target: closed` trigger.
> 
> Drops the job-level `if:` gate that was only needed to distinguish between the two event types, reducing duplicate workflow executions and concurrency contention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71af7de036dcd879cdb2bbcf17ac3ce590e771b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->