### PR TITLE
ci: declare contents:write on build-toc workflow

### DIFF
--- a/.github/workflows/build-toc.yaml
+++ b/.github/workflows/build-toc.yaml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 concurrency:
   group: main-push
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Declare `permissions: contents: write` at workflow level in `build-toc.yaml`
- Makes the `git push origin HEAD:main` step independent of repo-level default `GITHUB_TOKEN` permissions (matches `update-token-count.yml`)

## Context
Addresses [Copilot reviewer comment on #132](https://github.com/LouisShark/chatgpt_system_prompt/pull/132#discussion_r3106349121). Non-bug hardening — push currently works because the repo default is write-enabled, but explicit declaration prevents regressions if the default ever flips to read-only.

## Test plan
- [x] `yaml.safe_load` + `actionlint` — no new errors

https://claude.ai/code/session_01Mm5cao4DWuqXogHPaccCTy